### PR TITLE
Updates to getPeopleAll() to support change request assigned to as active people only #25

### DIFF
--- a/course-change/create.php
+++ b/course-change/create.php
@@ -63,7 +63,7 @@ function getGuidanceByCategory($cat, $categoriesFile) {
 $cat = isset($_GET['cat']) ? urldecode($_GET['cat']) : '';
 $categoriesFile = 'guidance.json';
 $guidance = getGuidanceByCategory($cat, $categoriesFile);
-
+$peopleActive = getPeopleAll($filteractive = true);
 
 ?>
 
@@ -325,7 +325,7 @@ $guidance = getGuidanceByCategory($cat, $categoriesFile);
                 <datalist id="people">
                     <?php
                     // Generate the datalist options
-                    foreach ($people as $person) {
+                    foreach ($peopleActive as $person) {
                         // Ensure the array has at least 3 elements for IDIR and Name
                         if (!empty($person[0]) && !empty($person[2])) {
                             $value = htmlspecialchars($person[0]); // Use IDIR (index 0) as the value

--- a/course-change/edit.php
+++ b/course-change/edit.php
@@ -75,6 +75,7 @@ function getGuidanceByCategory($cat, $categoriesFile) {
 $cat = urldecode($formData['category']) ?? '';
 $categoriesFile = 'guidance.json';
 $guidance = getGuidanceByCategory($cat, $categoriesFile);
+$peopleActive = getPeopleAll($filteractive = true);
 
 ?>
 
@@ -199,7 +200,7 @@ $guidance = getGuidanceByCategory($cat, $categoriesFile);
                     <input list="people" name="assign_to" id="assign_to" class="form-control" placeholder="Select a person" value="<?= htmlspecialchars($formData['assign_to'] ?? '') ?>">
                     <datalist id="people">
                         <?php
-                        foreach ($people as $person) {
+                        foreach ($peopleActive as $person) {
                             if (!empty($person[0]) && !empty($person[2])) {
                                 $value = htmlspecialchars($person[0]);
                                 $label = htmlspecialchars($person[2]);

--- a/inc/lsapp.php
+++ b/inc/lsapp.php
@@ -1225,26 +1225,40 @@ function getTips() {
 	return $tips;
 }
 
-//
-// Get a list of colleagues
-//
-function getPeopleAll() {
+/**
+ * Get a list of colleagues.
+ * 
+ * @param bool $filteractive return active people if true else all.
+ * 
+ * @return array returns an array of people.
+ */
+function getPeopleAll($filteractive = null) {
 
 	$path = build_path(BASE_DIR, 'data', 'people.csv');
 	$f = fopen($path, 'r');
 	fgetcsv($f); // Pop off the header
 	$list = array();
-	while ($row = fgetcsv($f)) {
-		// maybe check to see if active here?
-			array_push($list,$row);
+	// If we want to filter for active only
+	if ($filteractive) {
+		while ($row = fgetcsv($f)) {
+			if ($row[4] === 'Active') {
+				array_push($list,$row);
+			}
+		}
 	}
-	// Create a temp array to hold course names for sorting
+	// Otherwise get everyone
+	else {
+		while ($row = fgetcsv($f)) {
+			array_push($list,$row);
+		}
+	}
+	// Create a temp array to hold names for sorting
 	$tmp = array();
-	// Loop through the whole classes and add start dates to the temp array
+	// Loop through the whole people and add names to the temp array
 	foreach($list as $line) {
 		$tmp[] = $line[2];
 	}
-	// Use the temp array to sort all the classes by start date
+	// Use the temp array to sort all the people by name
 	array_multisort($tmp, SORT_ASC, $list);
 	
 	fclose($f);


### PR DESCRIPTION
Updated the `getPeopleAll()` function to allow for an optional parameter to return people with Active status.

The intent was to add additional functionality without impacting existing usage, and prevent duplication by creating a very similar new function.

With this update, I also updated the course request and edit pages to call with the new parameter so the Assigned To datalist only contains active people.